### PR TITLE
Fix photo ordering

### DIFF
--- a/src/app/photos/photos.component.html
+++ b/src/app/photos/photos.component.html
@@ -2,8 +2,8 @@
 
 <div class="p-2 w-100 mt-5 mb-1 d-flex justify-content-center">
     <lightgallery [settings]="settings" [onBeforeSlide]="onBeforeSlide" class="gallery">
-        <a *ngFor="let num of arr; let i = index" class="gallery-item" attr.data-src="../../assets/img/4ever/{{i+1}}.jpg">
-            <img src="../../assets/img/4ever/{{i+1}}.jpg" alt="Forever After gallery image {{i + 1}}" loading="lazy" />
+        <a *ngFor="let num of arr" class="gallery-item" attr.data-src="../../assets/img/4ever/{{num}}.jpg">
+            <img src="../../assets/img/4ever/{{num}}.jpg" alt="Forever After gallery image {{num}}" loading="lazy" />
         </a>
     </lightgallery>
 </div>

--- a/src/app/photos/photos.component.ts
+++ b/src/app/photos/photos.component.ts
@@ -8,7 +8,16 @@ import lgZoom from 'lightgallery/plugins/zoom';
   styleUrls: ['./photos.component.scss']
 })
 export class PhotosComponent {
-  arr = new Array(42);
+  // Explicitly list image numbers so that the display order can
+  // be customized if needed. Move image 28 to the end of the array
+  // to ensure it is not adjacent to image 15 in the rendered gallery.
+  arr: number[] = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25, 26, 27,
+    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    28
+  ];
   settings = {
     counter: false,
     plugins: [lgZoom],


### PR DESCRIPTION
## Summary
- ensure images are listed explicitly so order can be controlled
- place image 28 at the end of the list and use the number in the template

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685320e8e320832d82c3163a22bd395d